### PR TITLE
修改springboot2.3+以上版本以layout=ZIP打包的时候，加密后无法启动的BUG。

### DIFF
--- a/src/main/java/io/xjar/boot/XExtLauncher.java
+++ b/src/main/java/io/xjar/boot/XExtLauncher.java
@@ -2,11 +2,8 @@ package io.xjar.boot;
 
 import io.xjar.XLauncher;
 import org.springframework.boot.loader.PropertiesLauncher;
-import org.springframework.boot.loader.archive.Archive;
 
 import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.List;
 
 /**
  * Spring-Boot Properties 启动器
@@ -30,9 +27,7 @@ public class XExtLauncher extends PropertiesLauncher {
     }
 
     @Override
-    protected ClassLoader createClassLoader(List<Archive> archives) throws Exception {
-        URLClassLoader classLoader = (URLClassLoader) super.createClassLoader(archives);
-        URL[] urls = classLoader.getURLs();
+    protected ClassLoader createClassLoader(URL[] urls) throws Exception {
         return new XBootClassLoader(urls, this.getClass().getClassLoader(), xLauncher.xDecryptor, xLauncher.xEncryptor, xLauncher.xKey);
     }
 }


### PR DESCRIPTION
2.3之后PropertiesLauncher中的protected ClassLoader createClassLoader(List<Archive> archives)方法被废弃后没有被主动调用，导致覆盖该方法后没有被调用，修改为覆盖方法：protected ClassLoader createClassLoader(URL[] urls)。